### PR TITLE
hcxdumptool 6.3.x

### DIFF
--- a/Scripts/add-interface.sh
+++ b/Scripts/add-interface.sh
@@ -14,7 +14,7 @@ read_interface()
    INTERFACE_NAME=${INTERFACE_NAME:-$INTERFACE}
 }
 
-INTERFACES=$(hcxdumptool -I | tail -n +2 | cut -f 3)
+INTERFACES=$(hcxdumptool -l | awk 'BEGIN { FS = "\t" } ; { print $6 }')
 INTERFACES=($INTERFACES)
 
 for ITEM in ${INTERFACES[@]}; do

--- a/Scripts/add-interface.sh
+++ b/Scripts/add-interface.sh
@@ -60,7 +60,7 @@ echo "$MAC;$INTERFACE_NAME" >> /opt/wardriving/interfaces.txt
 echo "Enabling service"
 systemctl enable hcx@"$INTERFACE_NAME" --now
 
-echo "Reĺoading udev rules..."
+echo "Reloading udev rules..."
 udevadm control --reload-rules
 udevadm trigger --attr-match="subsystem=net"
 echo "Done, interface $INTERFACE_NAME was added. You should reconnect the interface now, just to be sure"

--- a/Scripts/autoupload.sh
+++ b/Scripts/autoupload.sh
@@ -21,7 +21,7 @@ upload()
                         echo "$LINE is the last session, not uploading"
                 else
                         echo "Session $LINE not uploaded yet, uploading.."
-                        /home/"$USER"/wpa-sec-api/upload-pcapng.sh "$WARDRIVE_DIR""$LINE"/* || retry
+                        /usr/bin/upload-pcapng.sh "$WARDRIVE_DIR""$LINE"/* || retry
                         echo "Session $LINE uploaded succesfully"
                         echo "$LINE" >> ~/.uploaded
                 fi

--- a/Scripts/hcx.sh
+++ b/Scripts/hcx.sh
@@ -17,11 +17,12 @@ ip link set "$INTERFACE" up
 wardrive()
 {
         HCX_OPTS=$(grep -w "$INTERFACE" /opt/wardriving/interfaces.txt | cut -d ";" -f 3)
+        # Added this, so in case of need to re-write the command or modify it, you only have to do it in one place
+        START_HCXDUMPTOOL=$(hcxdumptool --errormax=1 -i $INTERFACE -w $DIRECTORY/$SESSION/$INTERFACE-capture.pcapng --disable_deauthentication)
         if [[ $HCX_OPTS == "" ]]; then
-                hcxdumptool --error_max=1 -i $INTERFACE -o $DIRECTORY/$SESSION/$INTERFACE-capture.pcapng --disable_client_attacks --enable_status=95 --filtermode=1 --filterlist_ap=/opt/wardriving/whitelist.txt --filterlist_client=/opt/wardriving/whitelist-client.txt
-
+                $START_HCXDUMPTOOL
         else
-                hcxdumptool --error_max=1 -i $INTERFACE -o $DIRECTORY/$SESSION/$INTERFACE-capture.pcapng --disable_client_attacks --enable_status=95 --filtermode=1 --filterlist_ap=/opt/wardriving/whitelist.txt --filterlist_client=/opt/wardriving/whitelist-client.txt $HCX_OPTS
+                $START_HCXDUMPTOOL $HCX_OPTS
         fi
 }
 

--- a/Scripts/hcx.sh
+++ b/Scripts/hcx.sh
@@ -18,7 +18,7 @@ wardrive()
 {
         HCX_OPTS=$(grep -w "$INTERFACE" /opt/wardriving/interfaces.txt | cut -d ";" -f 3)
         # Added this, so in case of need to re-write the command or modify it, you only have to do it in one place
-        START_HCXDUMPTOOL=$(hcxdumptool --errormax=1 -i $INTERFACE -w $DIRECTORY/$SESSION/$INTERFACE-capture.pcapng --disable_deauthentication)
+        START_HCXDUMPTOOL=$(hcxdumptool --errormax=1 --onerror=reboot -i $INTERFACE -w $DIRECTORY/$SESSION/$INTERFACE-capture.pcapng --disable_deauthentication)
         if [[ $HCX_OPTS == "" ]]; then
                 $START_HCXDUMPTOOL
         else

--- a/finalize.sh
+++ b/finalize.sh
@@ -5,11 +5,21 @@ if [[ $EUID -ne 0 ]]; then
    exit 1
 fi
 
+NON_ROOT_USERS=$(awk -F: '($3>=1000)&&($1!="nobody"){print $1}' /etc/passwd)
+
+echo "Select non-root user:"
+
+select NON_ROOT_USER in "${NON_ROOT_USERS[@]}"; do
+   [ -n "${NON_ROOT_USER}" ] && break
+done
+
+echo "Selected user ${NON_ROOT_USER}, continuing with that..."
+
 TEMPFILE=$(mktemp)
 
 make-git()
 {
-	sudo -u pi bash -c "cd ~;git clone \"$1\";cd \"$2\";make;sudo make install"
+	sudo -u ${NON_ROOT_USER} bash -c "cd ~;git clone \"$1\";cd \"$2\";make;sudo make install"
 }
 
 # This script should be executed after rebooting after finishing install.sh
@@ -59,7 +69,7 @@ make-git "https://github.com/aircrack-ng/rtl8812au.git" rtl8812au
 
 echo "installing rtl88x2bu..."
 
-sudo -u pi bash -c "cd ~;git clone \"https://github.com/cilynx/rtl88x2bu.git\";cd \"rtl88x2bu\";make ARCH=arm;sudo make install"
+sudo -u ${NON_ROOT_USER} bash -c "cd ~;git clone \"https://github.com/cilynx/rtl88x2bu.git\";cd \"rtl88x2bu\";make ARCH=arm;sudo make install"
 
 cp Scripts/* /usr/bin/
 

--- a/finalize.sh
+++ b/finalize.sh
@@ -19,7 +19,16 @@ TEMPFILE=$(mktemp)
 
 make-git()
 {
+	# set environment variable for ALL software, some might need it and it's much simpler to just universally have it
 	export ARCH=arm
+
+	### Software-specific settings go in this section
+	# compile hcxdumptool without GPS and refresh-display support, see https://github.com/ZerBea/hcxdumptool/issues/301#issuecomment-1508011763
+	if [ "$2" = "hcxdumptool"]; do
+		cd \"$2\"; sed -i '/DSTATUSOUT/ s/./#&/' Makefile
+	fi
+
+	# clone the repo, compile and install
 	sudo -u ${NON_ROOT_USER} bash -c "cd ~;git clone \"$1\";cd \"$2\";make;sudo make install"
 }
 

--- a/finalize.sh
+++ b/finalize.sh
@@ -19,6 +19,7 @@ TEMPFILE=$(mktemp)
 
 make-git()
 {
+	export ARCH=arm
 	sudo -u ${NON_ROOT_USER} bash -c "cd ~;git clone \"$1\";cd \"$2\";make;sudo make install"
 }
 
@@ -69,7 +70,7 @@ make-git "https://github.com/aircrack-ng/rtl8812au.git" rtl8812au
 
 echo "installing rtl88x2bu..."
 
-sudo -u ${NON_ROOT_USER} bash -c "cd ~;git clone \"https://github.com/cilynx/rtl88x2bu.git\";cd \"rtl88x2bu\";make ARCH=arm;sudo make install"
+make-git "https://github.com/cilynx/rtl88x2bu.git" rtl88x2bu
 
 cp Scripts/* /usr/bin/
 

--- a/finalize.sh
+++ b/finalize.sh
@@ -28,6 +28,19 @@ make-git()
 		cd \"$2\"; sed -i '/DSTATUSOUT/ s/./#&/' Makefile
 	fi
 
+	# compile hcxtools without refresh-display support, see https://github.com/ZerBea/hcxdumptool#solve-dependencies
+	if [ "$2" = "hcxtools"]; do
+		cd \"$2\"; sed -i '/DSTATUSOUT/ s/./#&/' Makefile
+	fi
+
+	# TODO: recognize platform and set proper Makefile settings according to https://github.com/aircrack-ng/rtl8812au#for-raspberry-rpi
+	# depends on raspberrypi-kernel-headers, which we are trying to compile but it's broken/not implemented yet?
+
+	# compile rtl88x2bu for Raspberry pi, according to https://github.com/cilynx/rtl88x2bu#raspberry-pi-access-point, lines 16-17
+	if [ "$2" = "rtl88x2bu"]; do
+		cd \"$2\"; sed -i 's/I386_PC = y/I386_PC = n/' Makefile; sed -i 's/ARM_RPI = n/ARM_RPI = y/' Makefile
+	fi
+
 	# clone the repo, compile and install
 	sudo -u ${NON_ROOT_USER} bash -c "cd ~;git clone \"$1\";cd \"$2\";make;sudo make install"
 }

--- a/install.sh
+++ b/install.sh
@@ -14,6 +14,16 @@ fi
 
 echo "Warning: This script will only work on Raspberry Pi OS and possibly other Debian based systems."
 
+NON_ROOT_USERS=$(awk -F: '($3>=1000)&&($1!="nobody"){print $1}' /etc/passwd)
+
+echo "Select non-root user:"
+
+select NON_ROOT_USER in "${NON_ROOT_USERS[@]}"; do
+   [ -n "${NON_ROOT_USER}" ] && break
+done
+
+echo "Selected user ${NON_ROOT_USER}, continuing with that..."
+
 # Fix mt7610u drivers, see https://github.com/raspberrypi/firmware/issues/1563
 
 # echo "Checking if the correct version (1:20190114-2+rpt1) of firmware-misc-nonfree is installed... "
@@ -30,7 +40,7 @@ echo "Warning: This script will only work on Raspberry Pi OS and possibly other 
 
 apt update
 
-sudo -u pi bash -c 'wget http://ftp.uk.debian.org/debian/pool/non-free/f/firmware-nonfree/firmware-misc-nonfree_20190114-2_all.deb'
+sudo -u ${NON_ROOT_USER} bash -c 'wget http://ftp.uk.debian.org/debian/pool/non-free/f/firmware-nonfree/firmware-misc-nonfree_20190114-2_all.deb'
 dpkg -i firmware-misc-nonfree_20190114-2_all.deb
 apt-mark hold firmware-misc-nonfree
 

--- a/install.sh
+++ b/install.sh
@@ -34,7 +34,7 @@ sudo -u pi bash -c 'wget http://ftp.uk.debian.org/debian/pool/non-free/f/firmwar
 dpkg -i firmware-misc-nonfree_20190114-2_all.deb
 apt-mark hold firmware-misc-nonfree
 
-echo "Reinstalling kernel headers so we can compile drivers... (this might take a while)"
+# echo "Reinstalling kernel headers so we can compile drivers... (this might take a while)"
 
 # Remount /boot as read-write
 

--- a/packages.txt
+++ b/packages.txt
@@ -1,1 +1,1 @@
-pkg-config git libcurl4-openssl-dev libssl-dev hostapd macchanger zip jq build-essential libelf-dev dkms bc linux-source kmod cpio flex libncurses5-dev dwarves openssl
+pkg-config git libcurl4-openssl-dev libssl-dev hostapd macchanger zip jq build-essential libelf-dev dkms bc linux-source kmod cpio flex libncurses5-dev dwarves

--- a/packages.txt
+++ b/packages.txt
@@ -1,1 +1,1 @@
-pkg-config git libcurl4-openssl-dev libssl-dev hostapd macchanger zip jq build-essential libelf-dev dkms bc linux-source kmod cpio flex libncurses5-dev dwarves
+pkg-config git libcurl4-openssl-dev libssl-dev hostapd macchanger zip jq build-essential libelf-dev dkms bc linux-source kmod cpio flex libncurses5-dev dwarves openssl


### PR DESCRIPTION
Since [Release 6.3.0 of hcxdumptool ](https://github.com/ZerBea/hcxdumptool/releases/tag/6.3.0), there has been some major refactorization of code and the arguments. Sadly, the documentation on Git (or anywhere else on the internet for that matter) hasn't yet been updated, even the manpage is empty. The only way to get currently supported options is via `hcxdumptool -h`. So the command for running hcxdumptool has been edited to accommodate for that, plus everything deprecated has been removed, and the command itself has been moved to a variable, so it's not necessary to edit it on 2 places.

Sadly once again, many useful arguments and functionalities such as MAC whitelisting, AP whitelisting and higher verbosity seems to be deprecated. On unrelated note, I have kept all that functionality within the script, because _maybe_ one time, it'll get re-implemented. 